### PR TITLE
feat: implement `/api/v1/user` endpoint with session renewal`

### DIFF
--- a/infra/handlers.js
+++ b/infra/handlers.js
@@ -5,6 +5,8 @@ import {
   UnauthorizedError,
   ValidationError,
 } from "./errors/index.js";
+import * as cookie from "cookie";
+import session from "models/session.js";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -29,11 +31,22 @@ function onErrorHandler(error, request, response) {
   return response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 
+function setCookie(sessionToken, response) {
+  const setCookie = cookie.serialize("session_id", sessionToken, {
+    path: "/",
+    maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+  });
+  response.setHeader("Set-Cookie", setCookie);
+}
+
 const controller = {
   errorHandlers: {
     onError: onErrorHandler,
     onNoMatch: onNoMatchHandler,
   },
+  setCookie,
 };
 
 export default controller;

--- a/models/session.js
+++ b/models/session.js
@@ -1,7 +1,40 @@
 import database from "infra/database.js";
+import { UnauthorizedError } from "infra/errors";
 import crypto from "node:crypto";
 
 const EXPIRATION_IN_MILLISECONDS = 30 * 24 * 60 * 60 * 1000; // 30 Days
+
+async function findOneValidByToken(sessionToken) {
+  const sessionFound = await runSelectQuery(sessionToken);
+
+  return sessionFound;
+
+  async function runSelectQuery(sessionToken) {
+    const results = await database.query({
+      text: `
+          SELECT
+            *
+          FROM
+            sessions
+          WHERE
+            token = $1
+            AND expires_at > NOW()
+          LIMIT
+            1
+          ;`,
+      values: [sessionToken],
+    });
+
+    if (results.rowCount === 0) {
+      throw new UnauthorizedError({
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+      });
+    }
+
+    return results.rows[0];
+  }
+}
 
 async function create(userId) {
   const token = crypto.randomBytes(48).toString("hex");
@@ -27,8 +60,36 @@ async function create(userId) {
   }
 }
 
+async function renew(sessionId) {
+  const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
+  const renewedSessionObject = runUpdateQuery(sessionId, expiresAt);
+
+  return renewedSessionObject;
+
+  async function runUpdateQuery(sessionId, expiresAt) {
+    const results = await database.query({
+      text: `
+        UPDATE
+          sessions
+        SET
+          expires_at = $2,
+          updated_at = NOW()
+        WHERE
+          id = $1
+        RETURNING
+          *
+        ;`,
+      values: [sessionId, expiresAt],
+    });
+
+    return results.rows[0];
+  }
+}
+
 const session = {
   create,
+  findOneValidByToken,
+  renew,
   EXPIRATION_IN_MILLISECONDS,
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -62,6 +62,36 @@ async function findOneByEmail(email) {
   }
 }
 
+async function findOneById(id) {
+  const userFound = await runSelectQuery(id);
+  return userFound;
+
+  async function runSelectQuery(id) {
+    const results = await database.query({
+      text: `
+          SELECT
+            *
+          FROM
+            users
+          WHERE
+            id = $1
+          LIMIT
+            1
+          ;`,
+      values: [id],
+    });
+
+    if (results.rowCount === 0) {
+      throw new NotFoundError({
+        message: "O id fornecido não foi encontrado no sistema.",
+        action: "Verifique se o id foi digitado corretamente.",
+      });
+    }
+
+    return results.rows[0];
+  }
+}
+
 async function create(userData) {
   // fluxo de execução
   await validateUniqueUsername(userData.username);
@@ -193,6 +223,7 @@ const user = {
   create,
   findOneByUsername,
   findOneByEmail,
+  findOneById,
   update,
 };
 

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -2,7 +2,6 @@ import { createRouter } from "next-connect";
 import controller from "infra/handlers.js";
 import authentication from "models/authentication.js";
 import session from "models/session.js";
-import * as cookie from "cookie";
 
 const router = createRouter();
 
@@ -20,13 +19,7 @@ async function postHandler(request, response) {
 
   const newSession = await session.create(authenticatedUser.id);
 
-  const setCookie = cookie.serialize("session_id", newSession.token, {
-    path: "/",
-    maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
-    secure: process.env.NODE_ENV === "production",
-    httpOnly: true,
-  });
-  response.setHeader("Set-Cookie", setCookie);
+  controller.setCookie(newSession.token, response);
 
   return response.status(201).json(newSession);
 }

--- a/pages/api/v1/user/index.js
+++ b/pages/api/v1/user/index.js
@@ -1,0 +1,27 @@
+import { createRouter } from "next-connect";
+import controller from "infra/handlers.js";
+import user from "models/user.js";
+import session from "models/session.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const sessionToken = request.cookies.session_id;
+
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const renewedSessionObject = await session.renew(sessionObject.id);
+
+  controller.setCookie(renewedSessionObject.token, response);
+
+  const userFound = await user.findOneById(sessionObject.user_id);
+
+  response.setHeader(
+    "Cache-Control",
+    "no-store, no-cache, max-age=0, must-revalidate",
+  ); // ninguém pode armazenar
+  return response.status(200).json(userFound);
+}

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -2,6 +2,7 @@ import orchestrator from "tests/orchestrator.js";
 import { version as uuidVersion } from "uuid";
 import session from "models/session.js";
 import setCookieParser from "set-cookie-parser";
+
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.clearDatabase();

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,0 +1,205 @@
+import session from "models/session.js";
+import orchestrator from "tests/orchestrator.js";
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/user", () => {
+  describe("Authenticated user", () => {
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithValidSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: "session_id=" + sessionObject.token,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const cacheControl = response.headers.get("Cache-control");
+
+      expect(cacheControl).toBe(
+        "no-store, no-cache, max-age=0, must-revalidate",
+      );
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: createdUser.id,
+        username: "UserWithValidSession",
+        email: createdUser.email,
+        password: createdUser.password,
+        created_at: createdUser.created_at.toISOString(),
+        updated_at: createdUser.updated_at.toISOString(),
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      // session renewal assertions
+      const renewedSessionObject = await session.findOneValidByToken(
+        sessionObject.token,
+      );
+
+      expect(renewedSessionObject.expires_at > sessionObject.expires_at).toBe(
+        true,
+      );
+
+      expect(renewedSessionObject.updated_at > sessionObject.updated_at).toBe(
+        true,
+      );
+
+      // set-cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: renewedSessionObject.token,
+        maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+        path: "/",
+        httpOnly: true,
+      });
+    });
+
+    test("With non-existent session", async () => {
+      const token =
+        "6279f7f493ccc1726d468044c02641e0970bb50a1ff128f1d263895c986e987c2152ce5e20b2824ec924f6e2fcc156a2";
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: "session_id=" + token,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILLISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: "session_id=" + sessionObject.token,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "Verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+
+    test("With almost expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(
+          Date.now() - session.EXPIRATION_IN_MILLISECONDS + 60 * 1000,
+        ), // Volta 29 dias no passado, faltando 1 minuto para expirar
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithAlmostExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: "session_id=" + sessionObject.token,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: createdUser.id,
+        username: "UserWithAlmostExpiredSession",
+        email: createdUser.email,
+        password: createdUser.password,
+        created_at: createdUser.created_at.toISOString(),
+        updated_at: createdUser.updated_at.toISOString(),
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      // session renewal assertions
+      const renewedSessionObject = await session.findOneValidByToken(
+        sessionObject.token,
+      );
+
+      expect(renewedSessionObject.expires_at > sessionObject.expires_at).toBe(
+        true,
+      );
+
+      expect(renewedSessionObject.updated_at > sessionObject.updated_at).toBe(
+        true,
+      );
+
+      // set-cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: renewedSessionObject.token,
+        maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+        path: "/",
+        httpOnly: true,
+      });
+    });
+  });
+
+  afterEach(async () => {
+    const response = await fetch("http://localhost:3000/api/v1/status");
+    const responseBody = await response.json();
+    if (responseBody.dependencies.database.opened_connections !== 1) {
+      throw new Error(
+        "Conexões que foram abertas não foram fechadas adequadamente.",
+      );
+    }
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,6 +1,7 @@
 import database from "infra/database.js";
 import migrator from "models/migrator.js";
 import user from "models/user.js";
+import session from "models/session.js";
 
 import retry from "async-retry";
 import { faker } from "@faker-js/faker/.";
@@ -41,11 +42,16 @@ async function createUser(userObject) {
   });
 }
 
+async function createSession(userId) {
+  return await session.create(userId);
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
   runPendingMigrations,
   createUser,
+  createSession,
 };
 
 export default orchestrator;


### PR DESCRIPTION
This pull request introduces new session management features and refactors cookie handling, while also adding a new user endpoint and improving code consistency. The main changes include the implementation of session renewal and validation, centralization of cookie setting logic, and the addition of an authenticated user retrieval endpoint.

**Session management improvements:**

* Added `findOneValidByToken` and `renew` functions to `session.js`, enabling validation and renewal of user sessions based on tokens.
* Centralized cookie setting logic in a new `setCookie` function within `infra/handlers.js`, ensuring consistent handling of session cookies across the application.
* Refactored session creation in the sessions API to use the new centralized cookie setter. 

**User endpoint and model enhancements:**

* Added a new authenticated user endpoint at `pages/api/v1/user/index.js`, which validates and renews the session before returning user data.
* Implemented `findOneById` in `user.js` to support user lookup by ID, and updated exports accordingly.

**Code consistency and minor fixes:**

* Standardized formatting and corrected trailing commas and object values in multiple files for consistency.